### PR TITLE
SOL-15516 Fix Solidatus Monstache Go vulnerabilities CVE-2024-34156, CVE-2024-34158, CVE-2024-34155 & CVE-2024-24791

### DIFF
--- a/Solidatus-README.md
+++ b/Solidatus-README.md
@@ -36,3 +36,7 @@ Golang has 1 vulnerability CVE-2023-48795 which was fixed in golang.org/x/crypto
 # 2024-06-20
 
 Golang has 2 vulnerability CVE-2024-24790 and CVE-2024-24789 which was fixed in 1.21.11 hence manually updated go.mod to use 1.21.11. (latest on main branch was 1.21.6)
+
+# 2024-10-18
+
+Golang has 4 vulnerability CVE-2024-34156, CVE-2024-34158, CVE-2024-34155 and CVE-2024-24791 which was fixed in 1.21.11 hence manually updated go.mod to use 1.23.1 (latest on main branch was 1.21.11)

--- a/Solidatus-README.md
+++ b/Solidatus-README.md
@@ -39,4 +39,4 @@ Golang has 2 vulnerability CVE-2024-24790 and CVE-2024-24789 which was fixed in 
 
 # 2024-10-18
 
-Golang has 4 vulnerability CVE-2024-34156, CVE-2024-34158, CVE-2024-34155 and CVE-2024-24791 which was fixed in 1.21.11 hence manually updated go.mod to use 1.23.1 (latest on main branch was 1.21.11)
+Golang has 4 vulnerability CVE-2024-34156, CVE-2024-34158, CVE-2024-34155 and CVE-2024-24791 which was fixed in 1.23.1 hence manually updated go.mod to use 1.23.1 (latest on main branch was 1.21.11)

--- a/go.mod
+++ b/go.mod
@@ -36,4 +36,4 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
 
-go 1.21.11
+go 1.23.1

--- a/monstache.go
+++ b/monstache.go
@@ -82,7 +82,7 @@ var chunksRegex = regexp.MustCompile("\\.chunks$")
 var systemsRegex = regexp.MustCompile("system\\..+$")
 var exitStatus = 0
 
-const version = "6.7.10+6"
+const version = "6.7.10+7"
 const mongoURLDefault string = "mongodb://localhost:27017"
 const resumeNameDefault string = "default"
 const elasticMaxConnsDefault int = 4


### PR DESCRIPTION
[SOL-15516](https://solidatus.myjetbrains.com/youtrack/issue/SOL-15516) Fix Solidatus Monstache Go vulnerabilities CVE-2024-34156, CVE-2024-34158, CVE-2024-34155 & CVE-2024-24791