### PR TITLE
SOL-16761 Fix Solidatus Monstache Go vulnerability CVE-2025-22869

### DIFF
--- a/Solidatus-README.md
+++ b/Solidatus-README.md
@@ -51,4 +51,12 @@ Golang has 2 vulnerabilities CVE-2024-45336, CVE-2024-45341 which was fixed in 1
 
 2024-02-24
 
-Golang has 1 vulnerablity CVE-2025-22866 which was fixed in 1.23.6 hence manually updated go.mod to use 1.23.6.
+Golang has 1 vulnerability CVE-2025-22866 which was fixed in 1.23.6 hence manually updated go.mod to use 1.23.6.
+
+# 2024-04-28
+
+Golang has 1 vulnerability CVE-2025-22869 which was fixed in golang.org/x/crypto v0.35.0.The versions of golang.org/x/text v0.22.0, golang.org/x/sync v0.11.0 and golang.org/x/sys v0.30.0 bumped as related packages for golang.org/x/crypto v0.35.0.
+
+# 2024-04-28
+
+Golang has 1 vulnerability CVE-2025-22871 which was fixed in 1.23.8 hence manually updated go.mod to use 1.23.8.

--- a/go.mod
+++ b/go.mod
@@ -1,39 +1,39 @@
 module github.com/rwynn/monstache/v6
 
 require (
-github.com/BurntSushi/toml v1.2.1
-github.com/aws/aws-sdk-go v1.44.239
-github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
-github.com/evanphx/json-patch v5.6.0+incompatible
-github.com/fsnotify/fsnotify v1.5.1
-github.com/olivere/elastic/v7 v7.0.31
-github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f
-github.com/rwynn/gtm/v2 v2.1.2
-go.mongodb.org/mongo-driver v1.11.4
-gopkg.in/Graylog2/go-gelf.v2 v2.0.0-20191017102106-1550ee647df0
-gopkg.in/natefinch/lumberjack.v2 v2.0.0
+	github.com/BurntSushi/toml v1.2.1
+	github.com/aws/aws-sdk-go v1.44.239
+	github.com/coreos/go-systemd v0.0.0-20191104093116-d3cd4ed1dbcf
+	github.com/evanphx/json-patch v5.6.0+incompatible
+	github.com/fsnotify/fsnotify v1.5.1
+	github.com/olivere/elastic/v7 v7.0.31
+	github.com/robertkrimen/otto v0.0.0-20211024170158-b87d35c0b86f
+	github.com/rwynn/gtm/v2 v2.1.2
+	go.mongodb.org/mongo-driver v1.11.4
+	gopkg.in/Graylog2/go-gelf.v2 v2.0.0-20191017102106-1550ee647df0
+	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )
 
 require (
-github.com/golang/snappy v0.0.4 // indirect
-github.com/jmespath/go-jmespath v0.4.0 // indirect
-github.com/josharian/intern v1.0.0 // indirect
-github.com/klauspost/compress v1.15.1 // indirect
-github.com/kr/pretty v0.2.1 // indirect
-github.com/kr/text v0.2.0 // indirect
-github.com/mailru/easyjson v0.7.7 // indirect
-github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
-github.com/pkg/errors v0.9.1 // indirect
-github.com/serialx/hashring v0.0.0-20200727003509-22c0c7ab6b1b // indirect
-github.com/xdg-go/pbkdf2 v1.0.0 // indirect
-github.com/xdg-go/scram v1.1.1 // indirect
-github.com/xdg-go/stringprep v1.0.3 // indirect
-github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
-golang.org/x/crypto v0.31.0 // indirect
-golang.org/x/sync v0.10.0 // indirect
-golang.org/x/sys v0.28.0 // indirect
-golang.org/x/text v0.21.0 // indirect
-gopkg.in/sourcemap.v1 v1.0.5 // indirect
+	github.com/golang/snappy v0.0.4 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/klauspost/compress v1.15.1 // indirect
+	github.com/kr/pretty v0.2.1 // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/serialx/hashring v0.0.0-20200727003509-22c0c7ab6b1b // indirect
+	github.com/xdg-go/pbkdf2 v1.0.0 // indirect
+	github.com/xdg-go/scram v1.1.1 // indirect
+	github.com/xdg-go/stringprep v1.0.3 // indirect
+	github.com/youmark/pkcs8 v0.0.0-20201027041543-1326539a0a0a // indirect
+	golang.org/x/crypto v0.35.0 // indirect
+	golang.org/x/sync v0.11.0 // indirect
+	golang.org/x/sys v0.30.0 // indirect
+	golang.org/x/text v0.22.0 // indirect
+	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
 
-go 1.23.6
+go 1.23.8

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5y
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+golang.org/x/crypto v0.35.0 h1:b15kiHdrGCHrP6LvwaQ3c03kgNhhiMgvlhxHQhmg2Xs=
+golang.org/x/crypto v0.35.0/go.mod h1:dy7dXNW32cAb/6/PRuTNsix8T+vJAqvuIy5Bli/x0YQ=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
@@ -149,6 +151,8 @@ golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.10.0 h1:3NQrjDixjgGwUOCaF8w2+VYHv0Ve/vGYSbdkTa98gmQ=
 golang.org/x/sync v0.10.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
+golang.org/x/sync v0.11.0 h1:GGz8+XQP4FvTTrjZPzNKTMFtSXH80RAzG+5ghFPgK9w=
+golang.org/x/sync v0.11.0/go.mod h1:Czt+wKu1gCyEFDUtn0jG5QVvpJ6rzVqr5aXyt9drQfk=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -163,6 +167,8 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
 golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
+golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
@@ -175,6 +181,8 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.21.0 h1:zyQAAkrwaneQ066sspRyJaG9VNi/YJ1NfzcGB3hZ/qo=
 golang.org/x/text v0.21.0/go.mod h1:4IBbMaMmOPCJ8SecivzSH54+73PCFmPWxNTLm+vZkEQ=
+golang.org/x/text v0.22.0 h1:bofq7m3/HAFvbF51jz3Q9wLg3jkvSPuiZu/pD1XwgtM=
+golang.org/x/text v0.22.0/go.mod h1:YRoo4H8PVmsu+E3Ou7cqLVH8oXWIHVoX0jqUWALQhfY=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/monstache.go
+++ b/monstache.go
@@ -82,7 +82,7 @@ var chunksRegex = regexp.MustCompile("\\.chunks$")
 var systemsRegex = regexp.MustCompile("system\\..+$")
 var exitStatus = 0
 
-const version = "6.7.10+10"
+const version = "6.7.10+11"
 const mongoURLDefault string = "mongodb://localhost:27017"
 const resumeNameDefault string = "default"
 const elasticMaxConnsDefault int = 4


### PR DESCRIPTION
Update Go version to 1.23.8 and upgrade crypto dependencies:
- golang.org/x/crypto v0.35.0
- golang.org/x/text v0.22.0
- golang.org/x/sync v0.11.0
- golang.org/x/sys v0.30.0
