### PR TITLE
SOL-18128 Fix Solidatus Monstache Go vulnerability CVE-2025-61725, CVE-2025-61723, CVE-2025-58189, CVE-2025-58185, CVE-2025-61724, CVE-2025-58188, CVE-2025-58187, CVE-2025-58186, CVE-2025-58183, CVE-2025-47912, CVE-2025-61725, CVE-2025-61723, CVE-2025-58189, CVE-2025-58185.

### DIFF
--- a/Solidatus-README.md
+++ b/Solidatus-README.md
@@ -71,4 +71,4 @@ Golang has 1 vulnerability CVE-2025-47907 which was fixed in 1.24.6 hence manual
 
 # 2025-11-04
 
-Golang has 10 vulnerability CVE-2025-61725, CVE-2025-61723, CVE-2025-58189, CVE-2025-58185, CVE-2025-61724, CVE-2025-58188, CVE-2025-58187,  CVE-2025-58186,  CVE-2025-58183,  CVE-2025-47912,  CVE-2025-61725,  CVE-2025-61723,  CVE-2025-58189 and CVE-2025-58185 which was fixed in 1.24.8 hence manually updated go.mod to use 1.24.8.(latest on main branch was 1.24.6)
+Golang has 10 vulnerability CVE-2025-61725, CVE-2025-61723, CVE-2025-58189, CVE-2025-58185, CVE-2025-61724, CVE-2025-58188, CVE-2025-58187,  CVE-2025-58186,  CVE-2025-58183,  CVE-2025-47912,  CVE-2025-61725,  CVE-2025-61723,  CVE-2025-58189 and CVE-2025-58185 which was fixed in 1.24.9 hence manually updated go.mod to use 1.24.9.(latest on main branch was 1.24.6)

--- a/Solidatus-README.md
+++ b/Solidatus-README.md
@@ -68,3 +68,7 @@ Golang has 3 vulnerabilities CVE-2025-22874, CVE-2025-4673 and CVE-2025-0913. CV
 # 2025-08-20
 
 Golang has 1 vulnerability CVE-2025-47907 which was fixed in 1.24.6 hence manually updated go.mod to use 1.24.6.(latest on main branch was 1.24.4)
+
+# 2025-11-04
+
+Golang has 10 vulnerability CVE-2025-61725, CVE-2025-61723, CVE-2025-58189, CVE-2025-58185, CVE-2025-61724, CVE-2025-58188, CVE-2025-58187,  CVE-2025-58186,  CVE-2025-58183,  CVE-2025-47912,  CVE-2025-61725,  CVE-2025-61723,  CVE-2025-58189 and CVE-2025-58185 which was fixed in 1.24.8 hence manually updated go.mod to use 1.24.8.(latest on main branch was 1.24.6)

--- a/go.mod
+++ b/go.mod
@@ -37,4 +37,4 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
 
-go 1.24.8
+go 1.24.9

--- a/go.mod
+++ b/go.mod
@@ -37,4 +37,4 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
 
-go 1.24.6
+go 1.24.8

--- a/monstache.go
+++ b/monstache.go
@@ -82,7 +82,7 @@ var chunksRegex = regexp.MustCompile("\\.chunks$")
 var systemsRegex = regexp.MustCompile("system\\..+$")
 var exitStatus = 0
 
-const version = "6.7.10+13"
+const version = "6.7.10+14"
 const mongoURLDefault string = "mongodb://localhost:27017"
 const resumeNameDefault string = "default"
 const elasticMaxConnsDefault int = 4


### PR DESCRIPTION
SOL-18128: Fix Solidatus Monstache Go vulnerabilities

Resolved the following CVEs by updating dependencies and addressing security patches:
- CVE-2025-61725
- CVE-2025-61723
- CVE-2025-58189
- CVE-2025-58185
- CVE-2025-61724
- CVE-2025-58188
- CVE-2025-58187
- CVE-2025-58186
- CVE-2025-58183
- CVE-2025-47912

Updated Monstache Go packages to secure versions and validated build compatibility.
