### PR TITLE
SOL-18661 Update Go version to 1.24.12 and bump app version

### DIFF
--- a/Solidatus-README.md
+++ b/Solidatus-README.md
@@ -80,3 +80,6 @@ Golang has 12 vulnerabilities CVE-2025-58183, CVE-2025-58186, CVE-2025-58187, CV
 # 2025-12-10
 
 Golang has 2 vulnerability CVE-2025-47914 and CVE-2025-58181 which was fixed in golang.org/x/crypto v0.45.0.The versions of golang.org/x/text v0.31.0, golang.org/x/sync v0.18.0 and golang.org/x/sys v0.38.0 bumped as related packages for golang.org/x/crypto v0.45.0.
+
+# 2026-01-30
+Golang has 3 vulnerability CVE-2025-61730, CVE-2025-61728, CVE-2025-61726 which was fixed in 1.24.12 hence manually updated go.mod to use 1.24.12.(latest on main branch was 1.24.11)

--- a/go.mod
+++ b/go.mod
@@ -37,4 +37,4 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
 
-go 1.24.11
+go 1.24.12

--- a/monstache.go
+++ b/monstache.go
@@ -82,7 +82,7 @@ var chunksRegex = regexp.MustCompile("\\.chunks$")
 var systemsRegex = regexp.MustCompile("system\\..+$")
 var exitStatus = 0
 
-const version = "6.7.10+15"
+const version = "6.7.10+16"
 const mongoURLDefault string = "mongodb://localhost:27017"
 const resumeNameDefault string = "default"
 const elasticMaxConnsDefault int = 4


### PR DESCRIPTION
Fixed the vulnerabilities CVE-2025-61730, CVE-2025-61728, CVE-2025-61726