### PR TITLE
SOL-18944 Fix Solidatus Monstache Go vulnerability CVE-2026-27142, CVE-2026-27139, CVE-2026-27138, CVE-2026-27137 and CVE-2026-25679

### DIFF
--- a/Solidatus-README.md
+++ b/Solidatus-README.md
@@ -86,3 +86,6 @@ Golang has 3 vulnerability CVE-2025-61730, CVE-2025-61728, CVE-2025-61726 which 
 
 # 2026-02-06
 Golang has 2 vulnerability CVE-2025-61732, CVE-2025-68121 which was fixed in 1.25.7 hence manually updated go.mod to use 1.25.7.(latest on main branch was 1.24.12)
+
+# 2026-03-09
+Golang has 5 vulnerability CVE-2026-27142, CVE-2026-27139, CVE-2026-27138, CVE-2026-27137 and CVE-2026-25679 which was fixed in 1.26.1 hence manually updated go.mod to use 1.26.1.(latest on main branch was 1.25.7)

--- a/go.mod
+++ b/go.mod
@@ -37,4 +37,4 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
 
-go 1.25.7
+go 1.26.1

--- a/monstache.go
+++ b/monstache.go
@@ -82,7 +82,7 @@ var chunksRegex = regexp.MustCompile("\\.chunks$")
 var systemsRegex = regexp.MustCompile("system\\..+$")
 var exitStatus = 0
 
-const version = "6.7.10+17"
+const version = "6.7.10+18"
 const mongoURLDefault string = "mongodb://localhost:27017"
 const resumeNameDefault string = "default"
 const elasticMaxConnsDefault int = 4


### PR DESCRIPTION
Upgraded the Monstache Go dependency and rebuilt the Solidatus Monstache component with the latest patched Go version to remediate  CVE-2026-27142, CVE-2026-27139, CVE-2026-27138, CVE-2026-27137 and CVE-2026-25679