### PR TITLE
SOL-19455 Upgrade Monstache Go runtime to 1.26.3

### DIFF
--- a/Solidatus-README.md
+++ b/Solidatus-README.md
@@ -92,3 +92,7 @@ Golang has 5 vulnerability CVE-2026-27142, CVE-2026-27139, CVE-2026-27138, CVE-2
 
 # 2026-04-08
 Golang has 7 vulnerabilities CVE-2026-33810, CVE-2026-32289, CVE-2026-32288, CVE-2026-32283, CVE-2026-32282, CVE-2026-32281 and CVE-2026-32280 which are fixed in 1.26.2 hence manually updated go.mod to use 1.26.2. (latest on main branch is 1.26.1)
+
+# 2026-05-12
+
+Golang has 11 vulnerabilities CVE-2026-42501, CVE-2026-42499, CVE-2026-39836, CVE-2026-39820, CVE-2026-33814, CVE-2026-33811, CVE-2026-39826, CVE-2026-39825, CVE-2026-39823, CVE-2026-39819 and CVE-2026-39817 which were fixed in 1.26.3 hence manually updated go.mod to use 1.26.3. (latest on main branch was 1.26.2)

--- a/go.mod
+++ b/go.mod
@@ -37,4 +37,4 @@ require (
 	gopkg.in/sourcemap.v1 v1.0.5 // indirect
 )
 
-go 1.26.2
+go 1.26.3

--- a/monstache.go
+++ b/monstache.go
@@ -82,7 +82,7 @@ var chunksRegex = regexp.MustCompile("\\.chunks$")
 var systemsRegex = regexp.MustCompile("system\\..+$")
 var exitStatus = 0
 
-const version = "6.7.10+19"
+const version = "6.7.10+20"
 const mongoURLDefault string = "mongodb://localhost:27017"
 const resumeNameDefault string = "default"
 const elasticMaxConnsDefault int = 4


### PR DESCRIPTION
[SOL-19455](https://solidatus.myjetbrains.com/youtrack/issue/SOL-19455/CVE-placeholder-incase-build-master-miss)

Upgrades Monstache Go runtime from 1.26.2 to 1.26.3 to remediate current Go CVEs reported by Sentinel scans.